### PR TITLE
Hotfix comillas repo path

### DIFF
--- a/test_ej6.py
+++ b/test_ej6.py
@@ -8,14 +8,14 @@ CLIENT_CONFIG = {
 }
 
 def generate_agency_file(filename, register_amount):
-  os.makedirs(os.path.dirname(f'{os.environ['REPO_PATH']}/.data'), exist_ok=True)
-  with open(f'{os.environ['REPO_PATH']}/.data/{filename}', "w+") as file:
+  os.makedirs(os.path.dirname(f'{os.environ["REPO_PATH"]}/.data'), exist_ok=True)
+  with open(f'{os.environ["REPO_PATH"]}/.data/{filename}', "w+") as file:
     for i in range(register_amount):
       file.write(f'A,B,{str(i).zfill(8)},2000-01-01,{i}\n')
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ['REPO_PATH'])
+  os.chdir(os.environ["REPO_PATH"])
   git.reset_branch()
   git.switch_branch('ej6')
   docker.stop_all()

--- a/test_ej6.py
+++ b/test_ej6.py
@@ -15,7 +15,7 @@ def generate_agency_file(filename, register_amount):
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ["REPO_PATH"])
+  os.chdir(os.environ['REPO_PATH'])
   git.reset_branch()
   git.switch_branch('ej6')
   docker.stop_all()

--- a/test_ej7.py
+++ b/test_ej7.py
@@ -13,8 +13,8 @@ def make_id(i):
   return str(i).zfill(8)
 
 def generate_agency_file(filename, register_amount, winners):
-  os.makedirs(os.path.dirname(f'{os.environ['REPO_PATH']}/.data'), exist_ok=True)
-  with open(f'{os.environ['REPO_PATH']}/.data/{filename}', "w+") as file:
+  os.makedirs(os.path.dirname(f'{os.environ["REPO_PATH"]}/.data'), exist_ok=True)
+  with open(f'{os.environ["REPO_PATH"]}/.data/{filename}', "w+") as file:
     for i in range(register_amount):
     
       if i in winners:
@@ -26,7 +26,7 @@ def generate_agency_file(filename, register_amount, winners):
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ['REPO_PATH'])
+  os.chdir(os.environ["REPO_PATH"])
   git.reset_branch()
   git.switch_branch('ej7')
   docker.stop_all()

--- a/test_ej7.py
+++ b/test_ej7.py
@@ -26,7 +26,7 @@ def generate_agency_file(filename, register_amount, winners):
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ["REPO_PATH"])
+  os.chdir(os.environ['REPO_PATH'])
   git.reset_branch()
   git.switch_branch('ej7')
   docker.stop_all()

--- a/test_ej8.py
+++ b/test_ej8.py
@@ -10,7 +10,7 @@ CLIENT_CONFIG = {
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ["REPO_PATH"])
+  os.chdir(os.environ['REPO_PATH'])
   git.reset_branch()
   git.switch_branch('ej8')
   docker.stop_all()

--- a/test_ej8.py
+++ b/test_ej8.py
@@ -10,7 +10,7 @@ CLIENT_CONFIG = {
 
 @pytest.fixture(autouse=True, scope='module')
 def setup():
-  os.chdir(os.environ['REPO_PATH'])
+  os.chdir(os.environ["REPO_PATH"])
   git.reset_branch()
   git.switch_branch('ej8')
   docker.stop_all()


### PR DESCRIPTION
Buenas tardes

Me parece que las comillas simples en REPO_PATH están generando problemas al correr los tests

![image](https://github.com/user-attachments/assets/172e4af5-931b-48d9-a74e-486ecbb687a3)

Las cambio por comillas dobles para evitar el error de sintaxis

